### PR TITLE
Hardcode base_cmd path and fix method name

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -27,7 +27,7 @@ class Csharplint(Linter):
     syntax = ("c#", "unityc#")
 
     base_cmd = (
-        "mcs "
+        "gmcs.bat "
         " *"
         " -target:library"
         " -out:/tmp/errorcheck.dll"
@@ -118,7 +118,7 @@ class Csharplint(Linter):
                 return s.get(key)
         except:
             pass
-        return self.get_settings().get(key, default)
+        return self.get_view_settings().get(key, default)
 
     def expand_path(self, value, window=None, checkExists=True):
         if window == None:


### PR DESCRIPTION
A way to fix #4. When Unity3D wasn't available for Linux, I used Linux's Mono installation in order to avoid also using Wine to run gmcs.bat. Since Unity3D is now available for Linux and probably comes with it's own built-in Mono, then gmcs.bat should be default. Untested, trusting that it worked for Drunkendaknut.