### PR TITLE
Update to Sublime Linter 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A linter(software) called 'csharplint' does not exist, this simply uses Mono or 
 ![Unity C# Warning](https://lh4.googleusercontent.com/-9TlxxCqwPoU/VD1Wzhr9PhI/AAAAAAAABbc/9gxZ9ViXMMc/w895-h398-no/unitycsharplinter.png)
 
 ## Installation
-SublimeLinter 3 must be installed in order to use this plugin. If SublimeLinter 3 is not installed, please follow the instructions [here][installation].
+SublimeLinter 4 must be installed in order to use this plugin. If SublimeLinter 4 is not installed, please follow the instructions [here][installation].
 
 ### Linter installation
 Before using this plugin, you must ensure that Mono or the default .NET framework is installed on your system. Mono installations that come with software may also be used, like in the case of Unity 3D.
@@ -38,12 +38,35 @@ To install via Package Control, do the following:
 ## Settings
 For general information on how SublimeLinter works with settings, please see [Settings][settings]. For information on generic linter settings, please see [Linter Settings][linter-settings].
 
-In addition to the standard SublimeLinter settings, SublimeLinter-contrib-csharplint provides its own settings. Those marked as “Inline Setting” or “Inline Override” may also be [used inline][inline-settings].
+## Using with Unity
 
-|Setting|Description|Inline Setting|Inline Override|
-|:------|:----------|:------------:|:-------------:|
-|foo|Something.|&#10003;| |
-|bar|Something else.| |&#10003;|
+In order to run csharplint with Unity you will need to add the "completesharp_assemblies" list to your csharplint entry in the Sublime Linter settings. These will be platform dependent.
+
+On Windows your unity path will resemble:
+
+C:\\Program Files\\Unity\\Editor\\Data\\Managed\\
+
+On Mac OS:
+
+/Applications/Unity/Hub/Editor/2019.1.10f1/Unity.app/Contents/
+
+Bear in mind that Unity Hub will install Unity in different locations based on the version number.
+
+```
+"completesharp_assemblies": [
+    "**unity path**Managed/UnityEngine.dll",
+    "**unity path**Managed/UnityEditor.dll",
+    "**unity path**/Mono/lib/mono/unity/UnityScript.dll",
+    "**unity path**/Mono/lib/mono/unity/System.Core.dll",
+    "**unity path**/Mono/lib/mono/unity/System.dll",
+    "**unity path**/Mono/lib/mono/unity/mscorlib.dll",
+    "**unity path**/Mono/lib/mono/2.0/nunit.framework.dll",
+    "**unity project path**/Library/ScriptAssemblies/Assembly-CSharp.dll",
+    "**unity project path**/Library/ScriptAssemblies/Assembly-CSharp-Editor.dll",
+    "**unity project path**/Library/ScriptAssemblies/Assembly-UnityScript.dll",
+    "**unity project path**/Library/ScriptAssemblies/Assembly-CSharp-firstpass.dll"
+]
+```
 
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:

--- a/README.md
+++ b/README.md
@@ -52,21 +52,21 @@ On Mac OS:
 
 Bear in mind that Unity Hub will install Unity in different locations based on the version number.
 
-```
+<pre><code>
 "completesharp_assemblies": [
-    "**unity path**Managed/UnityEngine.dll",
-    "**unity path**Managed/UnityEditor.dll",
-    "**unity path**/Mono/lib/mono/unity/UnityScript.dll",
-    "**unity path**/Mono/lib/mono/unity/System.Core.dll",
-    "**unity path**/Mono/lib/mono/unity/System.dll",
-    "**unity path**/Mono/lib/mono/unity/mscorlib.dll",
-    "**unity path**/Mono/lib/mono/2.0/nunit.framework.dll",
-    "**unity project path**/Library/ScriptAssemblies/Assembly-CSharp.dll",
-    "**unity project path**/Library/ScriptAssemblies/Assembly-CSharp-Editor.dll",
-    "**unity project path**/Library/ScriptAssemblies/Assembly-UnityScript.dll",
-    "**unity project path**/Library/ScriptAssemblies/Assembly-CSharp-firstpass.dll"
+    "<b><i>unity path</i></b>Managed/UnityEngine.dll",
+    "<b><i>unity path</i></b>Managed/UnityEditor.dll",
+    "<b><i>unity path</i>i></Managed>b>/Mono/lib/mono/unity/UnityScript.dll",
+    "<b><i>unity path</i>i></Managed>b>/Mono/lib/mono/unity/System.Core.dll",
+    "<b><i>unity path</i>i></Managed>b>/Mono/lib/mono/unity/System.dll",
+    "<b><i>unity path</i>i></Managed>b>/Mono/lib/mono/unity/mscorlib.dll",
+    "<b><i>unity path</i>i></Managed>b>/Mono/lib/mono/2.0/nunit.framework.dll",
+    "<b><i>unity project path</i>i></Managed>b>/Library/ScriptAssemblies/Assembly-CSharp.dll",
+    "<b><i>unity project path</i>i></Managed>b>/Library/ScriptAssemblies/Assembly-CSharp-Editor.dll",
+    "<b><i>unity project path</i>i></Managed>b>/Library/ScriptAssemblies/Assembly-UnityScript.dll",
+    "<b><i>unity project path</i>i></Managed>b>/Library/ScriptAssemblies/Assembly-CSharp-firstpass.dll"
 ]
-```
+</pre></code>
 
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:

--- a/README.md
+++ b/README.md
@@ -54,19 +54,29 @@ Bear in mind that Unity Hub will install Unity in different locations based on t
 
 <pre><code>
 "completesharp_assemblies": [
-    "<b><i>unity path</i></b>Managed/UnityEngine.dll",
-    "<b><i>unity path</i></b>Managed/UnityEditor.dll",
-    "<b><i>unity path</i>i></Managed>b>/Mono/lib/mono/unity/UnityScript.dll",
-    "<b><i>unity path</i>i></Managed>b>/Mono/lib/mono/unity/System.Core.dll",
-    "<b><i>unity path</i>i></Managed>b>/Mono/lib/mono/unity/System.dll",
-    "<b><i>unity path</i>i></Managed>b>/Mono/lib/mono/unity/mscorlib.dll",
-    "<b><i>unity path</i>i></Managed>b>/Mono/lib/mono/2.0/nunit.framework.dll",
-    "<b><i>unity project path</i>i></Managed>b>/Library/ScriptAssemblies/Assembly-CSharp.dll",
-    "<b><i>unity project path</i>i></Managed>b>/Library/ScriptAssemblies/Assembly-CSharp-Editor.dll",
-    "<b><i>unity project path</i>i></Managed>b>/Library/ScriptAssemblies/Assembly-UnityScript.dll",
-    "<b><i>unity project path</i>i></Managed>b>/Library/ScriptAssemblies/Assembly-CSharp-firstpass.dll"
+    "<b><i>unity path</i></b> Managed/UnityEngine.dll",
+    "<b><i>unity path</i></b> Managed/UnityEditor.dll",
+    "<b><i>unity path</i></b> Mono/lib/mono/unity/UnityScript.dll",
+    "<b><i>unity path</i></b> Mono/lib/mono/unity/System.Core.dll",
+    "<b><i>unity path</i></b> Mono/lib/mono/unity/System.dll",
+    "<b><i>unity path</i></b> Mono/lib/mono/unity/mscorlib.dll",
+    "<b><i>unity path</i></b> Mono/lib/mono/2.0/nunit.framework.dll",
+    "<b><i>unity project path</i></b> Library/ScriptAssemblies/Assembly-CSharp.dll",
+    "<b><i>unity project path</i></b> Library/ScriptAssemblies/Assembly-CSharp-Editor.dll",
+    "<b><i>unity project path</i></b> Library/ScriptAssemblies/Assembly-UnityScript.dll",
+    "<b><i>unity project path</i></b> Library/ScriptAssemblies/Assembly-CSharp-firstpass.dll"
 ]
 </pre></code>
+
+e.g.:
+
+<pre><code>
+"completesharp_assemblies": [
+    "/Applications/Unity/Hub/Editor/2019.1.10f1/Unity.app/Contents/Managed/UnityEngine.dll",
+    ...
+]
+</pre></code>
+
 
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:

--- a/linter.py
+++ b/linter.py
@@ -38,6 +38,7 @@ class Csharplint(Linter):
         " -out:/tmp/errorcheck.dll"
     )
 
+    error_stream = SublimeLinter.lint.STREAM_STDERR
     base_cmd += args
 
     regex = (

--- a/linter.py
+++ b/linter.py
@@ -99,26 +99,16 @@ class Csharplint(Linter):
         for path in extra:
             newextra.extend(glob.glob(self.expand_path(path, window, False)))
         extra = newextra
-        cmd = ""
-        q = "\""
 
         result += ','.join([shlex.quote(newextra) for newextra in extra])
-        #print("Result: $ '" + result + "'")
-        #result += "%s%s%s" % (q, ";;--;;".join(extra), q)
-        #
         result += " -nostdlib" # Unity has its own
 
         return result
 
-    # following are copied from completionscommon package:
     def get_setting(self, key, default=None):
-        try:
-            s = sublime.active_window().active_view().settings()
-            if s.has(key):
-                return s.get(key)
-        except:
-            pass
-        return self.get_view_settings().get(key, default)
+        settings = sublime.active_window().active_view().settings()
+        return settings.get(key, default)
+
 
     def expand_path(self, value, window=None, checkExists=True):
         if window == None:

--- a/linter.py
+++ b/linter.py
@@ -10,15 +10,15 @@
 
 """This module exports the Csharplint plugin class."""
 
-import sublime
 import shlex
 
 # for completionscommon functions
 import re
 import glob
 import os
+import sublime
 
-from SublimeLinter.lint import Linter, util
+from SublimeLinter.lint import Linter
 
 class Csharplint(Linter):
 
@@ -60,15 +60,16 @@ class Csharplint(Linter):
         if not extra:
             return result + " $file"
 
-        result += " -r:"
-
         newextra = []
         window = sublime.active_window()
         for path in extra:
             newextra.extend(glob.glob(self.expand_path(path, window, False)))
-        extra = newextra
 
-        result += ','.join([shlex.quote(newextra) for newextra in extra])
+        folders = set([os.path.dirname(path) for path in newextra])
+        assemblies = set([os.path.basename(path) for path in newextra])
+
+        result += '-lib:' + ','.join([shlex.quote(newextra) for newextra in folders])
+        result += '-r:' + ','.join([shlex.quote(newextra) for newextra in assemblies])
         result += " -nostdlib" # Unity has its own
 
         return result + " $file"

--- a/linter.py
+++ b/linter.py
@@ -26,7 +26,6 @@ class Csharplint(Linter):
 
     defaults = {
         'selector': 'source.cs',
-        '--filter=,': ''
     }
 
     platform = sublime.platform()

--- a/linter.py
+++ b/linter.py
@@ -29,9 +29,9 @@ class Csharplint(Linter):
     }
 
     platform = sublime.platform()
-    gmcsFile = "gmcs.bat" if platform == "windows" else "gmcs"
-    gmcsFile += " "
-    base_cmd = gmcsFile
+    compilerFile = "mcs.bat" if platform == "windows" else "mcs"
+    compilerFile += " "
+    base_cmd = compilerFile
     args = (
         " *"
         " -target:library"

--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,7 @@ import glob
 import os
 import sublime
 
-from SublimeLinter.lint import Linter
+from SublimeLinter.lint import Linter, STREAM_STDERR
 
 class Csharplint(Linter):
 

--- a/linter.py
+++ b/linter.py
@@ -86,7 +86,7 @@ class Csharplint(Linter):
 
         extra = []
         extra = self.get_setting("completesharp_assemblies", [])
-        if len(extra) == 0:
+        if not extra:
             return result
 
         #result += ","

--- a/linter.py
+++ b/linter.py
@@ -58,7 +58,7 @@ class Csharplint(Linter):
 
         extra = self.settings.get("completesharp_assemblies", [])
         if not extra:
-            return result
+            return result + " $file"
 
         result += " -r:"
 
@@ -71,7 +71,7 @@ class Csharplint(Linter):
         result += ','.join([shlex.quote(newextra) for newextra in extra])
         result += " -nostdlib" # Unity has its own
 
-        return result
+        return result + " $file"
 
     def expand_path(self, value, window=None, checkExists=True):
         if window == None:

--- a/linter.py
+++ b/linter.py
@@ -47,12 +47,6 @@ class Csharplint(Linter):
         r'^(?P<filename>.+\.cs)\((?P<line>\d+),(?P<col>\d+)\): (?:(?P<error>error)|(?P<warning>warning)) \w+: (?P<message>.+)'
     )
     tempfile_suffix = '.cs'
-    error_stream = util.STREAM_BOTH  # errors are on stderr
-    executable = None
-    executable_path = '<builtin>'
-    multiline = False
-    line_col_base = (1, 1)
-    word_re = None
 
     def cmd(self):
         """

--- a/linter.py
+++ b/linter.py
@@ -28,8 +28,8 @@ class Csharplint(Linter):
     platform = sublime.platform()
     gmcsFile = "gmcs.bat" if platform == "windows" else "gmcs"
     gmcsFile += " "
-    base_cmd = (
-        gmcsFile
+    base_cmd = gmcsFile
+    args = (
         " *"
         " -target:library"
         " -out:/tmp/errorcheck.dll"
@@ -37,6 +37,9 @@ class Csharplint(Linter):
         #" sdk:3.5" # Unity uses .NET 3.5
         #" -r:./*.dll" # Recursively add all libraries within the folder of file
     )
+
+    base_cmd += args
+
     regex = (
         r'^(?P<filename>.+\.cs)\((?P<line>\d+),(?P<col>\d+)\): (?:(?P<error>error)|(?P<warning>warning)) \w+: (?P<message>.+)'
     )

--- a/linter.py
+++ b/linter.py
@@ -56,8 +56,7 @@ class Csharplint(Linter):
 
         result = self.base_cmd
 
-        extra = []
-        extra = self.get_setting("completesharp_assemblies", [])
+        extra = self.settings.get("completesharp_assemblies", [])
         if not extra:
             return result
 
@@ -73,11 +72,6 @@ class Csharplint(Linter):
         result += " -nostdlib" # Unity has its own
 
         return result
-
-    def get_setting(self, key, default=None):
-        settings = sublime.active_window().active_view().settings()
-        return settings.get(key, default)
-
 
     def expand_path(self, value, window=None, checkExists=True):
         if window == None:

--- a/linter.py
+++ b/linter.py
@@ -25,9 +25,11 @@ class Csharplint(Linter):
     """Provides an interface to csharplint."""
 
     syntax = ("c#", "unityc#")
-
+    platform = sublime.platform()
+    gmcsFile = "gmcs.bat" if platform == "windows" else "gmcs"
+    gmcsFile += " "
     base_cmd = (
-        "gmcs.bat "
+        gmcsFile
         " *"
         " -target:library"
         " -out:/tmp/errorcheck.dll"

--- a/linter.py
+++ b/linter.py
@@ -24,7 +24,11 @@ class Csharplint(Linter):
 
     """Provides an interface to csharplint."""
 
-    syntax = ("c#", "unityc#")
+    defaults = {
+        'selector': 'source.cs',
+        '--filter=,': ''
+    }
+
     platform = sublime.platform()
     gmcsFile = "gmcs.bat" if platform == "windows" else "gmcs"
     gmcsFile += " "
@@ -45,21 +49,10 @@ class Csharplint(Linter):
     )
     tempfile_suffix = '.cs'
     error_stream = util.STREAM_BOTH  # errors are on stderr
-    defaults = {
-        '--filter=,': '',
-    }
-    #comment_re = r'\s*/[/*]'
-    inline_settings = None
-    inline_overrides = 'filter'
-
     executable = None
     executable_path = '<builtin>'
-    version_args = '--version'
-    version_re = r'(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 1.0'
     multiline = False
     line_col_base = (1, 1)
-    selectors = {}
     word_re = None
 
     def split_match(self, match):

--- a/linter.py
+++ b/linter.py
@@ -41,7 +41,7 @@ class Csharplint(Linter):
     base_cmd += args
 
     regex = (
-        r'^(?P<filename>.+\.cs)\((?P<line>\d+),(?P<col>\d+)\): (?:(?P<error>error)|(?P<warning>warning)) \w+: (?P<message>.+)'
+        r'^(?P<filename>.+\.cs)\((?P<line>\d+),(?P<col>\d+)\): (?:(?P<error>error)|(?P<warning>warning)) (?P<code>\w+): (?P<message>.+)'
     )
     tempfile_suffix = '.cs'
 
@@ -96,6 +96,7 @@ class Csharplint(Linter):
                 for path in [os.path.join(f, m.group('file'))] \
                 if checkExists and os.path.exists(path) or not checkExists
             ]
+
         value = re.sub(r'\${project_path:(?P<file>[^}]+)}', lambda m: len(get_existing_files(m)) > 0 and get_existing_files(m)[0] or m.group('file'), value)
         value = re.sub(r'\${env:(?P<variable>[^}]+)}', lambda m: os.getenv(m.group('variable')) if os.getenv(m.group('variable')) else "%s_NOT_SET" % m.group('variable'), value)
         value = re.sub(r'\${home}', os.getenv('HOME') if os.getenv('HOME') else "HOME_NOT_SET", value)

--- a/linter.py
+++ b/linter.py
@@ -68,8 +68,8 @@ class Csharplint(Linter):
         folders = set([os.path.dirname(path) for path in newextra])
         assemblies = set([os.path.basename(path) for path in newextra])
 
-        result += '-lib:' + ','.join([shlex.quote(newextra) for newextra in folders])
-        result += '-r:' + ','.join([shlex.quote(newextra) for newextra in assemblies])
+        result += ' -lib:' + ','.join([shlex.quote(newextra) for newextra in folders])
+        result += ' -r:' + ','.join([shlex.quote(newextra) for newextra in assemblies])
         result += " -nostdlib" # Unity has its own
 
         return result + " $file"

--- a/linter.py
+++ b/linter.py
@@ -55,24 +55,6 @@ class Csharplint(Linter):
     line_col_base = (1, 1)
     word_re = None
 
-    def split_match(self, match):
-        """
-        Extract and return values from match.
-
-        We override this method so that the error:
-            No copyright message found.
-            You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
-        that appears on line 0 (converted to -1 because of line_col_base), can be displayed.
-
-        """
-
-        match, line, col, error, warning, message, near = super().split_match(match)
-
-        if line is not None and line == -1 and message:
-            line = 0
-
-        return match, line, col, error, warning, message, near
-
     def cmd(self):
         """
         Return the command line to execute.

--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,7 @@ import glob
 import os
 import sublime
 
-from SublimeLinter.lint import Linter
+from SublimeLinter.lint import Linter, STREAM_STDERR
 
 class Csharplint(Linter):
 
@@ -38,7 +38,7 @@ class Csharplint(Linter):
         " -out:/tmp/errorcheck.dll"
     )
 
-    error_stream = SublimeLinter.lint.STREAM_STDERR
+    error_stream = STREAM_STDERR
     base_cmd += args
 
     regex = (

--- a/linter.py
+++ b/linter.py
@@ -36,9 +36,6 @@ class Csharplint(Linter):
         " *"
         " -target:library"
         " -out:/tmp/errorcheck.dll"
-        #" -out:stdout" doesn't work like that
-        #" sdk:3.5" # Unity uses .NET 3.5
-        #" -r:./*.dll" # Recursively add all libraries within the folder of file
     )
 
     base_cmd += args
@@ -64,7 +61,6 @@ class Csharplint(Linter):
         if not extra:
             return result
 
-        #result += ","
         result += " -r:"
 
         newextra = []


### PR DESCRIPTION
Hi,

I've updated the module to Sublime Linter 4 and the new mcs compiler. 

Some other changes:
- I've separated the compiler arguments into assemblies and folders using the extra -libs flag
- the regex now supports the code key
- I removed the split_match overload. The syntax has changed in SL4 and I wasn't getting the copyright warning.

Tom